### PR TITLE
Add github-commits.coffee to hubot

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -38,6 +38,7 @@
         - lodash
         - moment
         - chrono-node
+        - gitio2
       hubot_custom_scripts:
         - achievement_unlocked.coffee
         - ackbar.coffee
@@ -52,6 +53,7 @@
         - dealwithit.coffee
         - decide.coffee
         - fortune.coffee
+        - github-commits.coffee
         - github-status.coffee
         - grumpycat.coffee
         - hackernews.coffee


### PR DESCRIPTION
Add a webhook that points to `http://<hubot-host>:8080/hubot/gh-commits?room=sprint@<jabber-host>` to all the repositories that we care about.

I tested it with karenc/hubot-deployment:

```
11:26 < aha> Got 1 new commit from karen chan on hubot-deployment
11:26 < aha>   * Add github-commits.coffee to hubot (https://git.io/vLYNn)
```

```
11:32 < aha> karenc created: refs/heads/test-create-branch: refs/heads/master
11:33 < aha> karenc deleted: refs/heads/test-create-branch
```
